### PR TITLE
define d3 to use as module

### DIFF
--- a/src/orbit.js
+++ b/src/orbit.js
@@ -1,3 +1,5 @@
+var d3 = require('d3');
+
 module.exports = function() {
   var currentTickStep = 0;
   var orbitNodes;


### PR DESCRIPTION
When using the layout as an ES6 module, d3 is not defined.